### PR TITLE
Update Program.cs

### DIFF
--- a/BivConnection/Program.cs
+++ b/BivConnection/Program.cs
@@ -137,7 +137,7 @@ namespace BivConnection
                 using (var reader = new StreamReader(stream))
                 {
                     var result = reader.ReadToEnd();
-                    return Encoding.ASCII.GetBytes(result);
+                    return Encoding.UTF8.GetBytes(result);
                 }
             }
         }


### PR DESCRIPTION
Adviseer om de encoding van het XBRL bestand te doen op basis van UTF-8 ipv ASCII. Indien XSD enumeraties met diakritisch tekens worden gebruikt, dan zal het XBRL bestand bij validatie worden afgekeurd. Een voorbeeld wanneer het fout gaat is 'Coöperatie'. Ook bestaat de kans dat bij digitaal ondertekenen de hash door verschillende partijen anders wordt berekend.